### PR TITLE
Add via header for use in mozdef.

### DIFF
--- a/webserver_configurations/OpenID_Connect/Nginx/conf.d/openidc_layer.lua
+++ b/webserver_configurations/OpenID_Connect/Nginx/conf.d/openidc_layer.lua
@@ -87,6 +87,7 @@ end
 ngx.req.set_header("REMOTE_USER", session.data.id_token.user_id)
 ngx.req.set_header("OIDC_CLAIM_ACCESS_TOKEN", session.data.access_token)
 ngx.req.set_header("OIDC_CLAIM_ID_TOKEN", session.data.enc_id_token)
+ngx.req.set_header("via",session.data.id_token.email)
 
 local function build_headers(t, name)
   for k,v in pairs(t) do


### PR DESCRIPTION
SockJS (used in meteor/mozdef) is opinionated about what headers it allows through and does not pass all headers. 
https://github.com/sockjs/sockjs-node/blob/8b03b3b1e7be14ee5746847f517029cb3ce30ca7/src/transport.coffee#L132
'via' is one that is whitelisted and seems appropriate for sending the email used to auth a user.