### PR TITLE
Add support for second-opinion

### DIFF
--- a/webserver_configurations/OpenID_Connect/Nginx/conf.d/ldap_second_opinion.conf
+++ b/webserver_configurations/OpenID_Connect/Nginx/conf.d/ldap_second_opinion.conf
@@ -1,0 +1,37 @@
+server {
+  listen       443 ssl;
+  server_name  ldap-second-opinion.testrp.security.allizom.org;
+  root         /var/www/nginx/php;
+  error_page   500 502 503 504  /50x.html;
+  index index.html index.php;
+  location = /50x.html {
+    root   /usr/share/nginx;
+  }
+  # "cookie" session storage won't work as cookies will be >4k, which then will be truncated and fail decoding
+  set $session_storage shm;
+  set $session_cookie_persistent on;
+  set $session_cookie_path "/";
+  # SSI check must be off or Nginx will kill our sessions when using lua-resty-session (which we do use)
+  set $session_check_ssi off;
+  set $session_secret #Output of openssl rand -hex 32 for example (must be 32 characters);
+  # Where your OIDC config is
+  set $config_loader "second_opinion/second_opinion_options.lua";
+
+  ssl_certificate      "/etc/letsencrypt/live/ldap-second-opinion.testrp.security.allizom.org/fullchain.pem";
+  ssl_certificate_key  "/etc/letsencrypt/live/ldap-second-opinion.testrp.security.allizom.org/privkey.pem";
+
+  # Uuh, PHP ;-)
+  location ~ \.php$ {
+    fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+  }
+
+
+  # Loads our shim/layer for openidc
+  location / {
+    access_by_lua_file 'conf/conf.d/second_opinion/openidc_second_opinion_layer.lua';
+  }
+  include ../letsencrypt.conf;
+}

--- a/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua
+++ b/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua
@@ -108,8 +108,8 @@ if not ok then
 end
 
 -- Authenticate with the primary OP if necessary
-local res, err, url, session = oidc.authenticate(primary.opts)
-primary.session = session
+local res, err, url
+res, err, url, primary.session= oidc.authenticate(primary.opts)
 
 -- Check if authentication succeeded, otherwise kick the user out
 if err then
@@ -126,8 +126,7 @@ secondary.opts.authorization_params = secondary.opts.authorization_params and se
 secondary.opts.authorization_params.login_hint = primary.session.data.id_token.email
 
 -- Authenticate with the secondary OP if necessary
-local res, err, url, session = oidc.authenticate(secondary.opts, nil, secondary.session_opts)
-secondary.session = session
+res, err, url, secondary.session = oidc.authenticate(secondary.opts, nil, secondary.session_opts)
 
 -- Check if authentication succeeded, otherwise kick the user out
 if err then
@@ -152,8 +151,19 @@ local groups = get_group_intersection(primary.session, secondary.session)
 primary.session.data.user.groups = groups
 primary.session.data.id_token.groups = groups
 
--- Access control: only allow specific users in (this is optional, without it all authenticated users are allowed in)
--- (TODO: add example)
+-- Access control: only allow users that are members of specific groups
+-- to access the site. This is optional as group membership is passed to the
+-- backing service in the HTTP headers and the backing service can govern
+-- access based on that group information.
+
+--local allowed_groups = Set.new({
+--  "MyFirstExampleGroupName",
+--  "MySecondExampleGroupName"
+--})
+--if next(Set.intersection(allowed_groups, Set.new(primary.session.data.user.groups))) == nil then
+--  -- user is not a member of any allowed_groups
+--  ngx.exit(ngx.HTTP_FORBIDDEN)
+--end
 
 -- Set headers with user info and OIDC claims for the underlaying web application to use (this is optional)
 -- These header names are voluntarily similar to Apaches mod_auth_openidc, but may of course be modified

--- a/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua
+++ b/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua
@@ -1,0 +1,176 @@
+-- Lua reference for nginx: https://github.com/openresty/lua-nginx-module
+-- Lua reference for openidc: https://github.com/pingidentity/lua-resty-openidc
+local oidc = require("resty.openidc")
+local cjson = require( "cjson" )
+
+Set = {}
+
+function Set.new (t)
+  local set = {}
+  for _, l in ipairs(t) do set[l] = true end
+  return set
+end
+
+function Set.union (a,b)
+  local res = Set.new{}
+  for k in pairs(a) do res[k] = true end
+  for k in pairs(b) do res[k] = true end
+  return res
+end
+
+function Set.intersection (a,b)
+  local res = Set.new{}
+  for k in pairs(a) do
+    res[k] = b[k]
+  end
+  return res
+end
+
+function Set.a_not_in_b (a,b)
+  local res = Set.new{}
+  for k in pairs(a) do
+    if b[k] == nil then
+      res[k] = a[k]
+    end
+  end
+  return res
+end
+
+function Set.tostring (set)
+  local s = "{"
+  local sep = ""
+  for e in pairs(set) do
+    s = s .. sep .. e
+    sep = ", "
+  end
+  return s .. "}"
+end
+
+function Set.print (s)
+  print(Set.tostring(s))
+end
+
+function Set.totable(set)
+  local res={}
+  local n=0
+
+  for k,_ in pairs(set) do
+    n=n+1
+    res[n]=k
+  end
+  return res
+end
+
+local function table_to_string(table)
+  local s = ""
+  for _,v in pairs(table) do
+    s = s and s.."|"..v or v
+  end
+  return s
+end
+
+local function compare_sessions(s1, s2)
+  -- check that both OPs authenticated the same user
+  local res = s1.data.user.email == s2.data.user.email
+  if res == false then
+    ngx.log(ngx.ERR, "User authenticated as different identities in primary and secondary auth")
+  end
+  return res
+end
+
+local function get_group_intersection(s1, s2)
+  -- given two sessions return the OIDC claimed groups present in both sessions
+  return Set.totable(Set.intersection(Set.new(s1.data.user.groups and s1.data.user.groups or {}), Set.new(s2.data.user.groups and s2.data.user.groups or {})))
+end
+
+local function build_headers(t, name)
+  for k,v in pairs(t) do
+    -- unpack tables
+    if type(v) == "table" then
+      local j = cjson.encode(v)
+      ngx.req.set_header("OIDC_CLAIM_"..name..k, j)
+    else
+      ngx.req.set_header("OIDC_CLAIM_"..name..k, tostring(v))
+    end
+  end
+end
+
+-- Load config
+primary = {}
+secondary = {}
+local f, e = loadfile(ngx.var.config_loader)
+if f == nil then
+  ngx.log(ngx.ERR, "can't initialize loadfile: "..e)
+end
+ok, e = pcall(f)
+if not ok then
+  ngx.log(ngx.ERR, "can't load configuration: "..e)
+end
+
+-- Authenticate with the primary OP if necessary
+local res, err, url, session = oidc.authenticate(primary.opts)
+primary.session = session
+
+-- Check if authentication succeeded, otherwise kick the user out
+if err then
+  if primary.session ~= nil then
+    primary.session:destroy()
+  end
+  ngx.redirect(primary.opts.logout_path)
+end
+
+ngx.log(ngx.DEBUG, "Primary authentication completed")
+
+-- Pass the user identity from the primary OP to the secondary OP
+secondary.opts.authorization_params = secondary.opts.authorization_params and secondary.opts.authorization_params or {}
+secondary.opts.authorization_params.login_hint = primary.session.data.id_token.email
+
+-- Authenticate with the secondary OP if necessary
+local res, err, url, session = oidc.authenticate(secondary.opts, nil, secondary.session_opts)
+secondary.session = session
+
+-- Check if authentication succeeded, otherwise kick the user out
+if err then
+  ngx.log(ngx.ERR, "Error during secondary authentication")
+  if secondary.session ~= nil then
+    secondary.session:destroy()
+  end
+  ngx.redirect(secondary.opts.logout_path)
+end
+
+ngx.log(ngx.DEBUG, "Secondary authentication completed")
+
+-- Compare the results of both authentication attempts
+if not compare_sessions(primary.session, secondary.session) then
+  primary.session:destroy()
+  secondary.session:destroy()
+  ngx.redirect(primary.opts.logout_path)
+end
+
+-- Replace the group list with the intersection of the group lists returned from each OP
+local groups = get_group_intersection(primary.session, secondary.session)
+primary.session.data.user.groups = groups
+primary.session.data.id_token.groups = groups
+
+-- Access control: only allow specific users in (this is optional, without it all authenticated users are allowed in)
+-- (TODO: add example)
+
+-- Set headers with user info and OIDC claims for the underlaying web application to use (this is optional)
+-- These header names are voluntarily similar to Apaches mod_auth_openidc, but may of course be modified
+ngx.req.set_header("REMOTE_USER", primary.session.data.id_token.email)
+ngx.req.set_header("X-Forwarded-User", primary.session.data.id_token.email)
+ngx.req.set_header("PRIMARY_OIDC_CLAIM_ACCESS_TOKEN", primary.session.data.access_token)
+ngx.req.set_header("PRIMARY_OIDC_CLAIM_ID_TOKEN", primary.session.data.enc_id_token)
+ngx.req.set_header("SECONDARY_OIDC_CLAIM_ACCESS_TOKEN", secondary.session.data.access_token)
+ngx.req.set_header("SECONDARY_OIDC_CLAIM_ID_TOKEN", secondary.session.data.enc_id_token)
+ngx.req.set_header("UNCORROBORATED_GROUPS", Set.totable(Set.a_not_in_b(Set.new(primary.session), Set.new(secondary.session))))
+ngx.req.set_header("via",primary.session.data.id_token.email)
+
+
+build_headers(primary.session.data.id_token, "ID_TOKEN_")
+build_headers(primary.session.data.user, "USER_PROFILE_")
+build_headers(secondary.session.data.id_token, "ID_TOKEN_SECONDARY_")
+build_headers(secondary.session.data.user, "USER_PROFILE_SECONDARY_")
+
+-- Flat groups, useful for some RP's that won't read JSON
+ngx.req.set_header("X-Forwarded-Groups", table_to_string(groups))

--- a/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/second_opinion_options.lua
+++ b/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/second_opinion_options.lua
@@ -1,0 +1,35 @@
+-- lua-resty-openidc options
+primary = {  -- Table containing options for the primary OIDC OP
+  opts = {   -- resty.openidc options
+    redirect_uri_path = "/redirect_uri",
+    discovery = "https://auth-dev.mozilla.auth0.com/.well-known/openid-configuration",
+    client_id = "CLIENT ID GOES HERE",
+    client_secret = "CLIENT SECRET GOES HERE",
+    scope = "openid email profile",
+    iat_slack = 600,
+    redirect_uri_scheme = "https",
+    logout_path = "/logout",
+    redirect_after_logout_uri = "https://testrp.security.allizom.org/?uri=https://ldap-second-opinion.testrp.security.allizom.org/",
+    refresh_session_interval = 900
+  },
+  session_opts = {  -- resty.session options
+    name = "primary"
+  }
+}
+secondary = {  -- Table containing options for the secondary OIDC OP
+  opts = {   -- resty.openidc options
+    redirect_uri_path = "/second-opinion/redirect_uri",
+    discovery = "https://second-opinion.security.mozilla.org/.well-known/openid-configuration",
+    client_id = "CLIENT ID GOES HERE",
+    client_secret = "CLIENT SECRET GOES HERE",
+    scope = "openid email profile",
+    iat_slack = 600,
+    redirect_uri_scheme = "https",
+    logout_path = "/logout",
+    redirect_after_logout_uri = "https://testrp.security.allizom.org/?uri=https://ldap-second-opinion.testrp.security.allizom.org/",
+    refresh_session_interval = 900
+  },
+  session_opts = {  -- resty.session options
+    name = "secondary"
+  }
+}


### PR DESCRIPTION
This adds a new Nginx server which supports the
[second-opinion](https://github.com/gene1wood/second-opinion) model
which includes a new lua "layer" and a new options file.